### PR TITLE
Settings and Options custom build overrides

### DIFF
--- a/custom/custom.pri
+++ b/custom/custom.pri
@@ -45,6 +45,10 @@ QGC_ANDROID_PACKAGE = "org.cubepilot.herelink_qgroundcontrol"
 QGC_APP_DESCRIPTION = "Herelink QGroundControl"
 QGC_APP_COPYRIGHT   = "Copyright (C) 2023 Cubepilot. All rights reserved."
 
+# Remove code which the Herelink doesn't needf
+DEFINES += \
+    QGC_GST_TAISYNC_DISABLED
+
 # Our own, custom resources
 # Not yet used
 #RESOURCES += \

--- a/custom/src/HerelinkCorePlugin.cc
+++ b/custom/src/HerelinkCorePlugin.cc
@@ -1,5 +1,9 @@
 #include "HerelinkCorePlugin.h"
 
+#include "AutoConnectSettings.h"
+
+#include <list>
+
 QGC_LOGGING_CATEGORY(HerelinkCorePluginLog, "HerelinkCorePluginLog")
 
 HerelinkCorePlugin::HerelinkCorePlugin(QGCApplication *app, QGCToolbox* toolbox)
@@ -13,4 +17,42 @@ void HerelinkCorePlugin::setToolbox(QGCToolbox* toolbox)
     QGCCorePlugin::setToolbox(toolbox);
 
     _herelinkOptions = new HerelinkOptions(this, nullptr);
+}
+
+bool HerelinkCorePlugin::overrideSettingsGroupVisibility(QString name)
+{
+    // Hide all AutoConnect settings
+    return name != AutoConnectSettings::name;
+}
+
+bool HerelinkCorePlugin::adjustSettingMetaData(const QString& settingsGroup, FactMetaData& metaData)
+{
+    if (settingsGroup == AutoConnectSettings::settingsGroup) {
+        // We have to adjust the Herelink UDP autoconnect settings for the AirLink
+        if (metaData.name() == AutoConnectSettings::udpListenPortName) {
+            metaData.setRawDefaultValue(14551);
+        } else if (metaData.name() == AutoConnectSettings::udpTargetHostIPName) {
+            metaData.setRawDefaultValue(QStringLiteral("127.0.0.1"));
+        } else if (metaData.name() == AutoConnectSettings::udpTargetHostPortName) {
+            metaData.setRawDefaultValue(15552);
+        } else {
+            // Disable all the other autoconnect types
+            const std::list<const char *> disabledAndHiddenSettings = {
+                AutoConnectSettings::autoConnectPixhawkName,
+                AutoConnectSettings::autoConnectSiKRadioName,
+                AutoConnectSettings::autoConnectPX4FlowName,
+                AutoConnectSettings::autoConnectRTKGPSName,
+                AutoConnectSettings::autoConnectLibrePilotName,
+                AutoConnectSettings::autoConnectNmeaPortName,
+                AutoConnectSettings::autoConnectZeroConfName,
+            };
+            for (const char * disabledAndHiddenSetting : disabledAndHiddenSettings) {
+                if (disabledAndHiddenSetting == metaData.name()) {
+                    metaData.setRawDefaultValue(false);
+                }
+            }
+        }
+    }
+
+    return true; // Show all settings in ui
 }

--- a/custom/src/HerelinkCorePlugin.h
+++ b/custom/src/HerelinkCorePlugin.h
@@ -17,7 +17,9 @@ public:
     HerelinkCorePlugin(QGCApplication* app, QGCToolbox* toolbox);
 
     // Overrides from QGCCorePlugin
-    QGCOptions* options (void) final { return qobject_cast<QGCOptions*>(_herelinkOptions); }
+    QGCOptions* options                         (void) final { return qobject_cast<QGCOptions*>(_herelinkOptions); }
+    bool        overrideSettingsGroupVisibility (QString name) final;
+    bool        adjustSettingMetaData           (const QString& settingsGroup, FactMetaData& metaData) final;
 
     // Overrides from QGCTool
     void setToolbox(QGCToolbox* toolbox) final;

--- a/custom/src/HerelinkOptions.h
+++ b/custom/src/HerelinkOptions.h
@@ -8,4 +8,9 @@ class HerelinkOptions : public QGCOptions
 {
 public:
     HerelinkOptions(HerelinkCorePlugin* plugin, QObject* parent = NULL);
+
+    // QGCOptions overrides
+    bool wifiReliableForCalibration () const final { return true; }
+    bool showFirmwareUpgrade        () const final { return false; }
+    bool multiVehicleEnabled        () const final { return false; }
 };

--- a/src/Settings/AutoConnectSettings.cc
+++ b/src/Settings/AutoConnectSettings.cc
@@ -13,7 +13,7 @@
 #include <QQmlEngine>
 #include <QtQml>
 
-DECLARE_SETTINGGROUP(AutoConnect, "LinkManager")
+DECLARE_SETTINGGROUP(AutoConnect, "AutoConnect")
 {
     qmlRegisterUncreatableType<AutoConnectSettings>("QGroundControl.SettingsManager", 1, 0, "AutoConnectSettings", "Reference only"); \
 }


### PR DESCRIPTION
These changes do the following:
* Hide all auto-connect settings ui
* Turn off all auto-connect except for udp
* Overrides the udp auto-connect settings to what the Airunit wants
* Turns off the warning about calibration over WiFi
* Hides the firmware upgrade page
* Turns off multi-vehicle support

All changes made using custom build support which required no mainline code changes.

The puts this build in a flyable state on the Herelink.

Big things still remaining:
* Remove joystick page
* Add Buttons page
* Video changes