### PR TITLE
Implement video stream default settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Use WIP version on Herelink - based on QGC master
 * Support still not working
-    * Video
     * Save video to SD card
+    * Video HDMI 1 vs HDMI 3 selection
 * Download the latest APK from GitHub Actions Artifacts
 * Put it on an sd card
 * Put the sd card into your Herelink

--- a/custom/custom.pri
+++ b/custom/custom.pri
@@ -51,6 +51,10 @@ DEFINES += \
     NO_SERIAL_LINK
     QGC_DISABLE_BLUETOOTH
 
+# Enable Herelink AirUnit video config
+DEFINES += \
+    QGC_HERELINK_AIRUNIT_VIDEO
+
 # Our own, custom resources
 # Not yet used
 #RESOURCES += \

--- a/custom/src/HerelinkCorePlugin.cc
+++ b/custom/src/HerelinkCorePlugin.cc
@@ -64,6 +64,8 @@ bool HerelinkCorePlugin::adjustSettingMetaData(const QString& settingsGroup, Fac
     } else if (settingsGroup == VideoSettings::settingsGroup) {
         if (metaData.name() == VideoSettings::rtspTimeoutName) {
             metaData.setRawDefaultValue(60);
+        } else if (metaData.name() == VideoSettings::videoSourceName) {
+            metaData.setRawDefaultValue(VideoSettings::videoSourceHerelinkAirUnit);
         }
     } else if (settingsGroup == AppSettings::settingsGroup) {
         if (metaData.name() == AppSettings::androidSaveToSDCardName) {

--- a/src/Settings/VideoSettings.cc
+++ b/src/Settings/VideoSettings.cc
@@ -29,6 +29,8 @@ const char* VideoSettings::videoSourceMPEGTS            = QT_TRANSLATE_NOOP("Vid
 const char* VideoSettings::videoSource3DRSolo           = QT_TRANSLATE_NOOP("VideoSettings", "3DR Solo (requires restart)");
 const char* VideoSettings::videoSourceParrotDiscovery   = QT_TRANSLATE_NOOP("VideoSettings", "Parrot Discovery");
 const char* VideoSettings::videoSourceYuneecMantisG     = QT_TRANSLATE_NOOP("VideoSettings", "Yuneec Mantis G");
+const char* VideoSettings::videoSourceHerelinkAirUnit   = QT_TRANSLATE_NOOP("VideoSettings", "Herelink AirUnit");
+const char* VideoSettings::videoSourceHerelinkHotspot   = QT_TRANSLATE_NOOP("VideoSettings", "Herelink Hotspot");
 
 DECLARE_SETTINGGROUP(Video, "Video")
 {
@@ -48,6 +50,13 @@ DECLARE_SETTINGGROUP(Video, "Video")
     videoSourceList.append(videoSourceParrotDiscovery);
     videoSourceList.append(videoSourceYuneecMantisG);
 #endif
+
+#ifdef QGC_HERELINK_AIRUNIT_VIDEO
+    videoSourceList.append(videoSourceHerelinkAirUnit);
+#else
+    videoSourceList.append(videoSourceHerelinkHotspot);
+#endif
+
 #ifndef QGC_DISABLE_UVC
     QList<QCameraInfo> cameras = QCameraInfo::availableCameras();
     for (const QCameraInfo &cameraInfo: cameras) {

--- a/src/Settings/VideoSettings.h
+++ b/src/Settings/VideoSettings.h
@@ -73,6 +73,8 @@ public:
     static const char* videoSource3DRSolo;
     static const char* videoSourceParrotDiscovery;
     static const char* videoSourceYuneecMantisG;
+    static const char* videoSourceHerelinkAirUnit;
+    static const char* videoSourceHerelinkHotspot;
 
 signals:
     void streamConfiguredChanged    (bool configured);

--- a/src/VideoManager/VideoManager.cc
+++ b/src/VideoManager/VideoManager.cc
@@ -565,6 +565,8 @@ VideoManager::isGStreamer()
             videoSource == VideoSettings::videoSource3DRSolo ||
             videoSource == VideoSettings::videoSourceParrotDiscovery ||
             videoSource == VideoSettings::videoSourceYuneecMantisG ||
+            videoSource == VideoSettings::videoSourceHerelinkAirUnit ||
+            videoSource == VideoSettings::videoSourceHerelinkHotspot ||
             autoStreamConfigured();
 #else
     return false;
@@ -741,6 +743,10 @@ VideoManager::_updateSettings(unsigned id)
         settingsChanged |= _updateVideoUri(0, QStringLiteral("udp://0.0.0.0:8888"));
     else if (source == VideoSettings::videoSourceYuneecMantisG)
         settingsChanged |= _updateVideoUri(0, QStringLiteral("rtsp://192.168.42.1:554/live"));
+    else if (source == VideoSettings::videoSourceHerelinkAirUnit)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("rtsp://192.168.0.10:8554/H264Video"));
+    else if (source == VideoSettings::videoSourceHerelinkHotspot)
+        settingsChanged |= _updateVideoUri(0, QStringLiteral("rtsp://192.168.43.1:8554/fpv_stream"));
     else if (source == VideoSettings::videoDisabled || source == VideoSettings::videoSourceNoVideo)
         settingsChanged |= _updateVideoUri(0, "");
     else {


### PR DESCRIPTION
This cherry-picks the commit from https://github.com/mavlink/qgroundcontrol/pull/10798.

And adds the custom configuration on top to display the Herelink AirUnit config rather than the Herelink Hotspot config.

Seems to work for me on the bench.

Closes #9.